### PR TITLE
Always call JOSM over http

### DIFF
--- a/web.py
+++ b/web.py
@@ -39,7 +39,7 @@ for(var i=0; i<links.length; i++){
 </script>
 </body></html>'''
 
-josmtmpl='''<a class="im" href="https://127.0.0.1:8112/load_and_zoom?left={left}&right={right}&top={top}&bottom={bottom}">JOSM</a>&nbsp;\n'''
+josmtmpl='''<a class="im" href="http://127.0.0.1:8111/load_and_zoom?left={left}&right={right}&top={top}&bottom={bottom}">JOSM</a>&nbsp;\n'''
 idtmpl='''<a href="https://openstreetmap.org/edit?editor=id&lon={lon}&lat={lat}&zoom=17">iD</a>&nbsp;\n'''
 osmtmpl='''<a href="https://openstreetmap.org/#map=17/{lat}/{lon}">OSM</a></br>\n'''
 districtlists=collections.defaultdict(list)


### PR DESCRIPTION
Https in JOSM is unreliable and will be dropped soon. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

https://github.com/w3c/webappsec-mixed-content/commit/349501cdaa4b4dc1e2a8aacb216ced58fd316165
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.